### PR TITLE
Tags are alphanumeric

### DIFF
--- a/gedcom/__init__.py
+++ b/gedcom/__init__.py
@@ -10,7 +10,7 @@ import six
 
 __version__ = "0.1.0"
 
-line_format = re.compile("^(?P<level>[0-9]+) ((?P<id>@[a-zA-Z0-9]+@) )?(?P<tag>[_A-Z]+)( (?P<value>.*))?$")
+line_format = re.compile("^(?P<level>[0-9]+) ((?P<id>@[a-zA-Z0-9]+@) )?(?P<tag>[_A-Z0-9]+)( (?P<value>.*))?$")
 
 
 class GedcomFile(object):


### PR DESCRIPTION
According to:
http://homepages.rootsweb.ancestry.com/~pmcbride/gedcom/55gcch1.htm
and according to my gramps exports, tags are alphanumeric (including underscore)
