### PR TITLE
Extend name parsing

### DIFF
--- a/gedcom/__init__.py
+++ b/gedcom/__init__.py
@@ -427,6 +427,8 @@ class Individual(Element):
 
                 first = first.strip()
                 last = last.strip()
+            elif len(vals) > 3:
+                raise Exception("Malformed name field: " + preferred_name.value)
 
         return first, last
 

--- a/gedcom/__init__.py
+++ b/gedcom/__init__.py
@@ -422,13 +422,20 @@ class Individual(Element):
                 # malformed line
                 raise Exception
             elif len(vals) == 3:
-                # Normal
-                first, last, dud = vals
-
+                first, last, first_tail = vals
                 first = first.strip()
                 last = last.strip()
+                first_tail = first_tail.strip()
+
+                if not first:
+                    # only last name
+                    first = None
+                elif first_tail:
+                    # last name embedded in first name(s)
+                    first = " ".join([first, first_tail])
+
             elif len(vals) > 3:
-                raise Exception("Malformed name field: " + preferred_name.value)
+                raise Exception("Malformed NAME field: " + preferred_name.value)
 
         return first, last
 
@@ -591,7 +598,6 @@ class Family(Element):
         :rtype: list of :py:class:`Wife`
         """
         return self.get_list("WIFE")
-
 
 
 class Spouse(Element):

--- a/tests.py
+++ b/tests.py
@@ -283,6 +283,10 @@ class GedComTestCase(unittest.TestCase):
         gedcomfile = gedcom.parse_string("0 HEAD\n0 @I1@ INDI\n1 NAME Bob /Russel\n0 TRLR")
         self.assertRaises(Exception, lambda : list(gedcomfile.individuals)[0].name)
 
+    def testNameWithTooManySlashes(self):
+        gedcomfile = gedcom.parse_string("0 HEAD\n0 @I1@ INDI\n1 NAME Bob/Robert /Russel/\n\n0 TRLR")
+        self.assertRaises(Exception, lambda : list(gedcomfile.individuals)[0].name)
+
     def testDashInID(self):
         gedcomfile = gedcom.parse_string("0 HEAD\n0 @I1-123@ INDI\n1 NAME\n2 GIVN Bob\n0 TRLR")
         self.assertEqual(list(gedcomfile.individuals)[0].name, ('Bob', None))

--- a/tests.py
+++ b/tests.py
@@ -188,6 +188,18 @@ class GedComTestCase(unittest.TestCase):
         gedcomfile = gedcom.parse_string("0 HEAD\n0 @I1@ INDI\n1 NAME Bob /Cox/\n\n0 TRLR")
         self.assertEqual(gedcomfile['@I1@'].name, ('Bob', 'Cox'))
 
+    def testSupportNameWithOnlyFirstName(self):
+        gedcomfile = gedcom.parse_string("0 HEAD\n0 @I1@ INDI\n1 NAME William\n\n0 TRLR")
+        self.assertEqual(gedcomfile['@I1@'].name, ('William', None))
+
+    def testSupportNameWithOnlyLastName(self):
+        gedcomfile = gedcom.parse_string("0 HEAD\n0 @I1@ INDI\n1 NAME /Cox/\n\n0 TRLR")
+        self.assertEqual(gedcomfile['@I1@'].name, (None, 'Cox'))
+
+    def testSupportNameWithEmbeddedLastName(self):
+        gedcomfile = gedcom.parse_string("0 HEAD\n0 @I1@ INDI\n1 NAME Bob /Cox/ James\n\n0 TRLR")
+        self.assertEqual(gedcomfile['@I1@'].name, ('Bob James', 'Cox'))
+
     def testSaveFile(self):
         gedcomfile = gedcom.parse_string(GEDCOM_FILE)
         outputfile = tempfile.NamedTemporaryFile()


### PR DESCRIPTION
The application I used for exporting GEDCOM does not handle additional slashes in the NAME according to the standard, so for clarity I extended the exception thrown in that scenario.

I also added support for the other NAME variants allowed by the standard.